### PR TITLE
Unified object element and limit beacons to crossdomain iframe

### DIFF
--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -1045,23 +1045,13 @@ function OVVAsset(uid, dependencies) {
             swfContainer.style.zIndex = $ovv.DEBUG ? 99999 : -99999;
 
             var html =
-                '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                '<param name="movie" value="' + url + '" />' +
-                '<param name="quality" value="low" />' +
-                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
-                '<param name="bgcolor" value="#ffffff" />' +
-                '<param name="wmode" value="transparent" />' +
-                '<param name="allowScriptAccess" value="always" />' +
-                '<param name="allowFullScreen" value="false" />' +
-                '<!--[if !IE]>-->' +
                 '<object id="OVVBeacon_' + index + '_' + id + '" type="application/x-shockwave-flash" data="' + url + '" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                '<param name="quality" value="low" />' +
-                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
-                '<param name="bgcolor" value="#ff0000" />' +
-                '<param name="wmode" value="transparent" />' +
-                '<param name="allowScriptAccess" value="always" />' +
-                '<param name="allowFullScreen" value="false" />' +
-                '<!--<![endif]-->' +
+                    '<param name="quality" value="low" />' +
+                    '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
+                    '<param name="bgcolor" value="#ff0000" />' +
+                    '<param name="wmode" value="transparent" />' +
+                    '<param name="allowScriptAccess" value="always" />' +
+                    '<param name="allowFullScreen" value="false" />' +
                 '</object>';
 
             swfContainer.innerHTML = html;
@@ -1258,7 +1248,7 @@ function OVVAsset(uid, dependencies) {
 
     // only use the beacons if we're in an iframe, but go ahead and add them
     // during debug mode
-    if ($ovv.IN_IFRAME || $ovv.DEBUG) {
+    if (($ovv.servingScenario === $ovv.servingScenarioEnum.CrossDomainIframe) || $ovv.DEBUG) {
         // 'BEACON_SWF_URL' is String substituted from ActionScript
         createBeacons.bind(this)('BEACON_SWF_URL');
     } else if (player && player.onJsReady) {


### PR DESCRIPTION
- Unified object element since old versions of IE don't support beacons, and IE11+ is compliant with regular embed method. 
- Only create beacons for crossdomain iframe since same domain iframes now use geometry.